### PR TITLE
fix: Remove unused wasm dependency

### DIFF
--- a/src/Uno.Extensions.Logging.WebAssembly.Console/Uno.Extensions.Logging.WebAssembly.Console.csproj
+++ b/src/Uno.Extensions.Logging.WebAssembly.Console/Uno.Extensions.Logging.WebAssembly.Console.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
-		<PackageReference Include="Uno.Foundation.Runtime.WebAssembly" Version="3.3.0" />
+		<PackageReference Include="Uno.Foundation.Runtime.WebAssembly" Version="3.3.0" Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='net5.0'" />
 	</ItemGroup>
 
 </Project>

--- a/src/Uno.Extensions.Logging.WebAssembly.Console/WebAssemblyConsoleLogger.cs
+++ b/src/Uno.Extensions.Logging.WebAssembly.Console/WebAssemblyConsoleLogger.cs
@@ -6,10 +6,11 @@ using System;
 using System.Collections.Concurrent;
 using System.Text;
 using Microsoft.Extensions.Logging;
-using Uno.Foundation;
 
 #if NET7_0_OR_GREATER
 using System.Runtime.InteropServices.JavaScript;
+#else
+using Uno.Foundation;
 #endif
 
 namespace Uno.Extensions.Logging.WebAssembly
@@ -182,8 +183,10 @@ namespace Uno.Extensions.Logging.WebAssembly
 
         private static partial class NativeMethods
         {
+#if !NET7_0_OR_GREATER
             private static void Invoke(string method, string message)
                 => WebAssemblyRuntime.InvokeJS($"{method}(\"{WebAssemblyRuntime.EscapeJs(message)}\")");
+#endif
 
 #if NET7_0_OR_GREATER
             [JSImport("globalThis.console.debug")]


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Removes unused dependencies from loggers (Uno.Core is not needed anymore).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
